### PR TITLE
feat(api-rest): configure OpenAPI 3.0 and Swagger UI with Bearer auth

### DIFF
--- a/infrastructure/entry-points/api-rest/build.gradle
+++ b/infrastructure/entry-points/api-rest/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation project(":model")
     implementation project(":usecase")
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15")
 }
 
 //config to resolve SQL native query parameters

--- a/infrastructure/entry-points/api-rest/src/main/java/com/arka/config/OpenApiConfig.java
+++ b/infrastructure/entry-points/api-rest/src/main/java/com/arka/config/OpenApiConfig.java
@@ -1,0 +1,58 @@
+package com.arka.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+
+        final String securitySchemeName = "bearerAuth";
+
+        Server server = new Server();
+        server.setUrl("http://localhost:8080");
+        server.description("Open API Documentation");
+
+
+        Contact contact = new Contact();
+        contact.name("David Correa");
+        contact.email("davidcq55@gmail.com");
+
+        Info info = new Info()
+                .title("Arka")
+                .description("B2B Arka Backend Service")
+                .contact(contact)
+                .version("1.0")
+                .license(new License().name("Apache 2.0").url("http://localhost"));
+
+        SecurityRequirement security = new SecurityRequirement()
+                .addList(securitySchemeName);
+
+        Components components = new Components()
+                .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                        .name(securitySchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")
+                        .description("Enter your JWT token directly into the field below."));
+
+
+        return new OpenAPI()
+                .info(info)
+                .servers(List.of(server))
+                .addSecurityItem(security)
+                .components(components);
+    }
+}

--- a/infrastructure/entry-points/api-rest/src/main/java/com/arka/request/CreateShippingDetailRequest.java
+++ b/infrastructure/entry-points/api-rest/src/main/java/com/arka/request/CreateShippingDetailRequest.java
@@ -13,10 +13,7 @@ public record CreateShippingDetailRequest(
 
         String notes,
 
-        @Required(field = "status")
-        ShippingStatus status,
-
-        @Required(field = "id")
+        @Required(field = "orderId")
         Long orderId,
 
         @Required(field = "originAddressId")

--- a/infrastructure/entry-points/security/src/main/java/com/arka/config/CorsConfig.java
+++ b/infrastructure/entry-points/security/src/main/java/com/arka/config/CorsConfig.java
@@ -14,7 +14,8 @@ public class CorsConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
-        corsConfiguration.setAllowedOrigins(List.of("http://localhost:8080", "http://localhost:8081"));
+        corsConfiguration.setAllowedOrigins(List.of(
+                "http://localhost:8080"));
         corsConfiguration.setAllowedHeaders(List.of("*"));
         corsConfiguration.setAllowedMethods(List.of("GET", "POST", "OPTIONS"));
         corsConfiguration.setAllowCredentials(true);

--- a/infrastructure/entry-points/security/src/main/java/com/arka/config/SecurityConfig.java
+++ b/infrastructure/entry-points/security/src/main/java/com/arka/config/SecurityConfig.java
@@ -29,8 +29,13 @@ public class SecurityConfig {
                 .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfig.corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/error").permitAll()
+                        .requestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html").permitAll()
                         .requestMatchers("/actuator/health").permitAll()
                                 .anyRequest().authenticated())
+
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
- Add springdoc-openapi dependency to api-rest build.gradle.
- Create OpenApiConfig with metadata, JWT security scheme, and local server context.
- Permit unauthenticated access to Swagger UI and v3/api-docs endpoints in SecurityConfig.
- Update CORS config to only permit localhost:8080.
- Fix @Required validation field names in CreateShippingDetailRequest.